### PR TITLE
Use aws profile "admin" on S3 backend access too

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ To execute terraform configuration, you need to be using AWS credentials with su
 Terraform will find these credentails in your environment. Either ENV variables
 `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, OR your local [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where) by default in a profile called `admin`.
 
-Or you can ask it to look in a different profile with eg `terraform plan -var="aws_access_profile=other_profile_name"`.
+Or you can ask it to look in a different named profile with standard AWS_PROFILE env var, like `export AWS_PROFILE=other_profile_name`.
 
 We recommend you keep these high-privilege AWS credentails in your credentials file in a profile called admin.
 
-Beware, if you have the ENV varaibles set, they will always take precedence and be used!
+Beware, if you have the AWS_* ENV varaibles set, they will always take precedence and be used!
 
 ## We use workspace for production/staging tiers
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Or you can ask it to look in a different named profile with standard AWS_PROFILE
 
 We recommend you keep these high-privilege AWS credentails in your credentials file in a profile called admin.
 
-Beware, if you have the AWS_* ENV varaibles set, they will always take precedence and be used!
+**NOTE**, if you have the AWS_* ENV varaibles set, they will always take precedence and be used!
+
+**WARNING**, if you accidentally execute a terraform command without proper AWS credentials available, it may put your local terraform in a weird situation, where you need to re-run `terraform init` again after fixing credentials problems.  That should recover you and shouldn't result in any lasting problems though.
 
 ## We use workspace for production/staging tiers
 

--- a/backend.tf
+++ b/backend.tf
@@ -3,6 +3,10 @@
 
 terraform {
   backend "s3" {
+    # can't use terraform variable in backend config, have to hard-code this!
+    # can still be overridden with AWS_PROFILE shell env though.
+    profile = "admin"
+
     bucket = "scihist-digicoll-terraform-state"
     region = "us-east-1"
     key = "scihist-digicoll/terraform.tfstate"

--- a/locals.tf
+++ b/locals.tf
@@ -2,5 +2,12 @@ locals {
   name_prefix = "scihist-digicoll-${terraform.workspace}"
 
   service_tag = "kithe"
+
+  # this should probably match the profile in backend, which has
+  # to be a literal. Unless you have some reason to want to use
+  # different aws credentials with backend vs aws configured resources?
+  # That seems like trouble.
+  aws_access_profile = "admin"
 }
+
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,6 @@
+# terraform locals are essentially constants.
+# https://www.terraform.io/docs/language/values/locals.html
+
 locals {
   name_prefix = "scihist-digicoll-${terraform.workspace}"
 

--- a/providers.tf
+++ b/providers.tf
@@ -8,12 +8,12 @@ terraform {
 }
 
 provider "aws" {
-  profile = var.aws_access_profile
+  profile = local.aws_access_profile
   region = var.aws_region
 }
 
 provider "aws" {
   alias = "backup"
-  profile = var.aws_access_profile
+  profile = local.aws_access_profile
   region = var.aws_backup_region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
+# Terraform variables can be overridden from defaults by the caller by several
+# means, including a .tvvars file, the terraform command line, or special
+# TV_VARS_* ENV variables. https://www.terraform.io/docs/language/values/variables.html
+
 variable aws_region {
   default = "us-east-1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable aws_access_profile {
-  default = "admin"
-}
-
 variable aws_region {
   default = "us-east-1"
 }


### PR DESCRIPTION
Closes #1 

Our terraform state file (the "backend") is ALSO stored on S3. We were telling terraform to get AWS credentials from, by default, AWS credential profile 'admin' for when it created our actual AWS resources -- but we weren't telling it that for the backend itself! So backend itself was using default credentials and/or AWS_* ENV vars.

We fix that, and tell backend to use profile "admin" too. We can't use variables in terraform backend config, only string literal "admin". So to keep things consistent, we stop using an overrideable terraform variable for profile in providers too, we just use "locals" which is like a constant.

You can still override with AWS_PROFILE or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY in your shell ENV, these are still used to override, for both backend and provider, consistently!