### PR TITLE
Terraform changes to make consistent with current/desired S3 config

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -65,7 +65,7 @@ resource "aws_s3_bucket" "derivatives" {
 
         transition {
             days          = 30
-            storage_class = "STANDARD_IA"
+            storage_class = "INTELLIGENT_TIERING"
         }
     }
 
@@ -146,7 +146,7 @@ resource "aws_s3_bucket" "dzi" {
 
         transition {
             days          = 30
-            storage_class = "STANDARD_IA"
+            storage_class = "INTELLIGENT_TIERING"
         }
     }
 
@@ -359,7 +359,7 @@ resource "aws_s3_bucket" "originals" {
         id                                     = "scihist-digicoll-${terraform.workspace}-originals-IA-Rule"
         transition {
             days          = 30
-            storage_class = "STANDARD_IA"
+            storage_class = "INTELLIGENT_TIERING"
         }
     }
 

--- a/s3.tf
+++ b/s3.tf
@@ -61,7 +61,7 @@ resource "aws_s3_bucket" "derivatives" {
     }
     lifecycle_rule {
         enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-derivatives-IA-Rule"
+        id                                     = "scihist-digicoll-${terraform.workspace}-derivatives-IT-Rule"
 
         transition {
             days          = 30
@@ -142,7 +142,7 @@ resource "aws_s3_bucket" "dzi" {
     }
     lifecycle_rule {
         enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-dzi-IA-Rule"
+        id                                     = "scihist-digicoll-${terraform.workspace}-dzi-IT-Rule"
 
         transition {
             days          = 30
@@ -356,7 +356,7 @@ resource "aws_s3_bucket" "originals" {
 
     lifecycle_rule {
         enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-originals-IA-Rule"
+        id                                     = "scihist-digicoll-${terraform.workspace}-originals-IT-Rule"
         transition {
             days          = 30
             storage_class = "INTELLIGENT_TIERING"

--- a/shared_state_s3.tf
+++ b/shared_state_s3.tf
@@ -19,6 +19,7 @@ resource "aws_s3_bucket" "terraform_state" {
   tags                        = {
       "service" = local.service_tag
       "use"     = "terraform"
+       "S3-Bucket-Name" = "scihist-digicoll-terraform-state"
   }
 
   # Enable versioning so we can see the full revision history of our


### PR DESCRIPTION
Includes some changes to productio and staging. Will need to run terraform on both after we merge -- and then maybe double-check that what's live is what we want!

- make lifecycle rules match Chuck's specification and current deployment
- Standardize Lifecycle Rule names, "-IA-Rule" for Infrequent Access and "-IT-Rule" for "Intelligent Tiering"
- add bucket name tag to scihist-digicoll-terraform-state s3 bucket
