### PR TITLE
Turn off logging a second time

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -345,10 +345,10 @@ resource "aws_s3_bucket" "originals" {
         }
     }
 
-    logging {
-        target_bucket = "chf-logs"
-        target_prefix = "s3_server_access_${terraform.workspace}_originals/"
-    }
+    # logging {
+    #    target_bucket = "chf-logs"
+    #    target_prefix = "s3_server_access_${terraform.workspace}_originals/"
+    # }
 
     lifecycle_rule {
         enabled                                = true
@@ -422,10 +422,10 @@ resource "aws_s3_bucket" "originals_video" {
         }
     }
 
-    logging {
-        target_bucket = "chf-logs"
-        target_prefix = "s3_server_access_${terraform.workspace}_originals_video/"
-    }
+    # logging {
+    #    target_bucket = "chf-logs"
+    #    target_prefix = "s3_server_access_${terraform.workspace}_originals_video/"
+    # }
 
     lifecycle_rule {
         enabled                                = true


### PR DESCRIPTION
We now have a full week's worth of logs from AFTER the April 11th switch, so let's turn s3 logging back off.
Ref #17