### PR TITLE
Add video-derivatives bucket

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -99,6 +99,69 @@ resource "aws_s3_bucket_policy" "derivatives" {
     policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.derivatives.id })
 }
 
+# Video derivatives, expected to be mainly/only HLS. Set up in a separate bucket from
+# other videos for easier cost tracking. Also the method of creation/management differs.
+#
+# Set up to mimic the derivatives bucket.
+#
+# * EXCEPT: We've decided NOT to replicate to a backup bucket.
+# * NOTE: This is intentionally set to publically readable -- like our other
+#   derivatives bucket. In this case, signed URLs wouldn't work for HLS files,
+#   as the manifest files have references to static urls in them too.
+resource "aws_s3_bucket" "derivatives_video" {
+    bucket                      = "${local.name_prefix}-derivatives-video"
+
+    lifecycle {
+      prevent_destroy           = true
+    }
+
+    tags                        = {
+        "service" = local.service_tag
+        "use"     = "derivatives"
+        "S3-Bucket-Name" = "${local.name_prefix}-derivatives-video"
+    }
+
+    cors_rule {
+        allowed_headers = [
+            "*",
+        ]
+        allowed_methods = [
+            "GET",
+        ]
+        allowed_origins = [
+            "*",
+        ]
+        expose_headers  = []
+        max_age_seconds = 43200
+    }
+
+    lifecycle_rule {
+        enabled                                = true
+        id                                     = "Expire previous files"
+
+        noncurrent_version_expiration {
+            days = 30
+        }
+    }
+    lifecycle_rule {
+        enabled                                = true
+        id                                     = "scihist-digicoll-${terraform.workspace}-derivatives-IT-Rule"
+
+        transition {
+            days          = 30
+            storage_class = "INTELLIGENT_TIERING"
+        }
+    }
+
+    versioning {
+        enabled    = true
+    }
+}
+
+resource "aws_s3_bucket_policy" "derivatives-video" {
+    bucket = aws_s3_bucket.derivatives_video.id
+    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.derivatives_video.id })
+}
 
 
 #


### PR DESCRIPTION
To be used for HLS, but we'll name it video_derivatives generically, in case we have other derivatievs for download later -- our motivations for putting things in separate bucket would apply to such too, and it would just make sense to consoloidate them. Will name keypaths in bucket accordingly, for future expansion.

This PR does NOT set up a backup bucket with replication. Our initial discussions were that we did not need/want such. But we should defintiely go over it with Chuck/@CHF-IT-Staff

The bucket IS set to public read, like existing derivatives. We don't actually have a good way to provide signed url access to HLS, it wouldn't work as static files.

Ref: https://github.com/sciencehistory/scihist_digicoll/issues/1659
