### PR TITLE
CloudFront distribution for video derivatives (HLS)

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -57,3 +57,77 @@ resource "aws_cloudfront_distribution" "rails_static_assets" {
         minimum_protocol_version       = "TLSv1"
     }
 }
+
+
+# Video-derviatives cloudfront, in front of S3
+# * cheaper price class North America/Europe only
+# * add on cache-control header with far future caches for clients,
+#   since MediaConvert won't write those in our outputs in S3 already
+resource "aws_cloudfront_distribution" "staging-derivatives-video" {
+    comment                   = "staging-derivatives-video S3"
+    enabled                   = true
+    is_ipv6_enabled           = true
+
+    # North America/Europe only, cheaper price class
+    price_class               = "PriceClass_100"
+
+    origin {
+        domain_name  = "scihist-digicoll-${terraform.workspace}-derivatives-video.s3.${var.aws_region}.amazonaws.com"
+        origin_id    = "${terraform.workspace}-derivatives-video.s3"
+    }
+
+    default_cache_behavior {
+        allowed_methods        = [
+            "GET",
+            "HEAD",
+            "OPTIONS",
+        ]
+        cached_methods         = [
+            "GET",
+            "HEAD",
+            "OPTIONS",
+        ]
+
+        # We're already sending mp4 content, adding gzip compression on top
+        # won't help and may hurt.
+        compress               = false
+
+        target_origin_id       = "${terraform.workspace}-derivatives-video.s3"
+        viewer_protocol_policy = "https-only"
+
+        # AWS Managed policy for `Managed-CachingOptimizedForUncompressedObjects`
+        cache_policy_id        = "b2884449-e4de-46a7-ac36-70bc7f1ddd6d"
+
+        # references policy for far-future Cache-Control header to be added
+        response_headers_policy_id = aws_cloudfront_response_headers_policy.long-time-immutable-cache.id
+    }
+
+
+    restrictions {
+        geo_restriction {
+            locations        = []
+            restriction_type = "none"
+        }
+    }
+
+    viewer_certificate {
+        cloudfront_default_certificate = true
+        minimum_protocol_version       = "TLSv1"
+    }
+}
+
+# Used by any CloudFronts in front of content at "immutable" URLs (random URL
+# that will necessarily change if content does), but where origin (eg S3)
+# is not providing far-future Cache headers -- we add them in.
+resource "aws_cloudfront_response_headers_policy" "long-time-immutable-cache" {
+    name            = "long-time-immutable-cache"
+    comment         = "far future Cache-Control"
+
+    custom_headers_config {
+        items {
+            header   = "Cache-Control"
+            override = false
+            value    = "max-age=31536000, immutable"
+        }
+    }
+}

--- a/output.tf
+++ b/output.tf
@@ -3,3 +3,7 @@
 output "RAILS_ASSET_HOST" {
   value = aws_cloudfront_distribution.rails_static_assets.domain_name
 }
+
+output "S3_BUCKET_DERIVATIVES_VIDEO_HOST" {
+  value = aws_cloudfront_distribution.staging-derivatives-video.domain_name
+}


### PR DESCRIPTION
Ref https://github.com/sciencehistory/scihist_digicoll/issues/1659

Sets up a CloudFront distribution in front of our video derivatives bucket. 

Since we put our HLS video files at a unique URL that can be cached forever (any change in content would change URL too), we want it to be delivered to user with cache-for-a-long-time headers.  But the S3 files aren't including those response headeres (we can't tell MediaConvert to write them when it produces the S3 output files) -- so we tell the CloudFront distribution to add them in, no big deal. 