### PR TITLE
Use cloudfront policy name that will be unique in production/staging

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -120,7 +120,7 @@ resource "aws_cloudfront_distribution" "staging-derivatives-video" {
 # that will necessarily change if content does), but where origin (eg S3)
 # is not providing far-future Cache headers -- we add them in.
 resource "aws_cloudfront_response_headers_policy" "long-time-immutable-cache" {
-    name            = "long-time-immutable-cache"
+    name            = "long-time-immutable-cache-${terraform.workspace}"
     comment         = "far future Cache-Control"
 
     custom_headers_config {


### PR DESCRIPTION
Terraform thinks production and staging are entirely independent, even though they are both in the same AWS account. So without this, trying to run this in production after having already ran it in staging results in:

```
│ Error: error creating CloudFront Response Headers Policy (long-time-immutable-cache): ResponseHeadersPolicyAlreadyExists: Another response headers policy with the same name already exists within the aws account.
│ 	status code: 409, request id: 5885d966-953a-427f-8723-c84f005e5b01
│
│   with aws_cloudfront_response_headers_policy.long-time-immutable-cache,
│   on cloudfront.tf line 122, in resource "aws_cloudfront_response_headers_policy" "long-time-immutable-cache":
│  122: resource "aws_cloudfront_response_headers_policy" "long-time-immutable-cache" {
```

We don't *really* need two copies of the same policy... but for the way we're using terraform, it's simplest to do so, so we just add a -staging or -production on to the end of the policy name to make everything happy.
