### PR TITLE
Fix terraform derivatives-video resource name

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -63,8 +63,8 @@ resource "aws_cloudfront_distribution" "rails_static_assets" {
 # * cheaper price class North America/Europe only
 # * add on cache-control header with far future caches for clients,
 #   since MediaConvert won't write those in our outputs in S3 already
-resource "aws_cloudfront_distribution" "staging-derivatives-video" {
-    comment                   = "staging-derivatives-video S3"
+resource "aws_cloudfront_distribution" "derivatives-video" {
+    comment                   = "${terraform.workspace}-derivatives-video S3"
     enabled                   = true
     is_ipv6_enabled           = true
 

--- a/output.tf
+++ b/output.tf
@@ -5,5 +5,5 @@ output "RAILS_ASSET_HOST" {
 }
 
 output "S3_BUCKET_DERIVATIVES_VIDEO_HOST" {
-  value = aws_cloudfront_distribution.staging-derivatives-video.domain_name
+  value = aws_cloudfront_distribution.derivatives-video.domain_name
 }


### PR DESCRIPTION
Accidentally had one specific workspace name embedded in the resource name `staging-derivatives-video`, which was not right!

After making change, had to run, in both staging and production:

    terraform state mv aws_cloudfront_distribution.staging-derivatives-video aws_cloudfront_distribution.derivatives-video

To make the change in terraform state to match the change in config file.
