### PR TITLE
Add tags to our cloudfront distributions for easier cost report breakdowns

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -45,6 +45,11 @@ resource "aws_cloudfront_distribution" "rails_static_assets" {
         }
     }
 
+    tags                        = {
+        "Cloudfront-Distribution-Origin-Id" = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
+    }
+
+
     restrictions {
         geo_restriction {
             locations        = []
@@ -75,6 +80,14 @@ resource "aws_cloudfront_distribution" "derivatives-video" {
         domain_name  = "scihist-digicoll-${terraform.workspace}-derivatives-video.s3.${var.aws_region}.amazonaws.com"
         origin_id    = "${terraform.workspace}-derivatives-video.s3"
     }
+
+    # add tag matching bucket name tag used for S3 buckets themselves,
+    # for cost analysis.
+    tags                        = {
+        "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-derivatives-video.s3"
+        "S3-Bucket-Name" = "${local.name_prefix}-derivatives-video"
+    }
+
 
     default_cache_behavior {
         allowed_methods        = [


### PR DESCRIPTION
Added a "S3-Bucket-Name" tag to the bucket-based distro, to match the tags we have on actual S3 buckets, with same value as teh underlying bucket.

Also added a "Cloudfront-Distribution-Origin-Id" tag to both.

Ref #1772

This has already been applied in staging, will need to be applied to production after merge. (Applying changes to cloudfront distros takes a while, you hae to wait for it to complete). 
