### PR TITLE
Format `.tf` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ This configuration is configured to use a Remote S3 backend for terraform, in th
 * https://mohitgoyal.co/2020/09/30/upload-terraform-state-files-to-remote-backend-amazon-s3-and-azure-storage-account/
 
 
+
+## Formatting / linting
+
+We will try to keep the `.tf` files formatted using `terraform fmt *.tf` before committing. This makes the diffs a lot easier to read. We are considering making a pre-commit hook to enforce this practice.
+
 ## Sensitive info
 
 **Do not put sensitive info in this repository**. Such as credentials etc.

--- a/backend.tf
+++ b/backend.tf
@@ -7,10 +7,10 @@ terraform {
     # can still be overridden with AWS_PROFILE shell env though.
     profile = "admin"
 
-    bucket = "scihist-digicoll-terraform-state"
-    region = "us-east-1"
-    key = "scihist-digicoll/terraform.tfstate"
+    bucket         = "scihist-digicoll-terraform-state"
+    region         = "us-east-1"
+    key            = "scihist-digicoll/terraform.tfstate"
     dynamodb_table = "scihist-digicoll-terraform-state-locks"
-    encrypt = true
+    encrypt        = true
   }
 }

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -2,65 +2,65 @@
 
 resource "aws_cloudfront_distribution" "rails_static_assets" {
 
-    comment                        = "${terraform.workspace} static assets"
-    enabled                        = true
-    is_ipv6_enabled                = true
+  comment         = "${terraform.workspace} static assets"
+  enabled         = true
+  is_ipv6_enabled = true
 
-    default_cache_behavior {
-        allowed_methods        = [
-            "GET",
-            "HEAD",
-            "OPTIONS",
-        ]
-        cached_methods         = [
-            "GET",
-            "HEAD",
-            "OPTIONS",
-        ]
+  default_cache_behavior {
+    allowed_methods = [
+      "GET",
+      "HEAD",
+      "OPTIONS",
+    ]
+    cached_methods = [
+      "GET",
+      "HEAD",
+      "OPTIONS",
+    ]
 
-        target_origin_id       = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
-        viewer_protocol_policy = "https-only"
+    target_origin_id       = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
+    viewer_protocol_policy = "https-only"
 
-        forwarded_values {
-          query_string = false
-          cookies {
-            forward = "none"
-          }
-        }
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
     }
+  }
 
-    origin {
-        domain_name         = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
-        origin_id           = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
+  origin {
+    domain_name = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
+    origin_id   = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
 
-        custom_origin_config {
-            http_port                = 80
-            https_port               = 443
-            origin_protocol_policy   = "https-only"
-            origin_ssl_protocols     = [
-                "TLSv1",
-                "TLSv1.1",
-                "TLSv1.2",
-            ]
-        }
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols = [
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
     }
+  }
 
-    tags                        = {
-        "Cloudfront-Distribution-Origin-Id" = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
+  tags = {
+    "Cloudfront-Distribution-Origin-Id" = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
+  }
+
+
+  restrictions {
+    geo_restriction {
+      locations        = []
+      restriction_type = "none"
     }
+  }
 
-
-    restrictions {
-        geo_restriction {
-            locations        = []
-            restriction_type = "none"
-        }
-    }
-
-    viewer_certificate {
-        cloudfront_default_certificate = true
-        minimum_protocol_version       = "TLSv1"
-    }
+  viewer_certificate {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+  }
 }
 
 
@@ -69,78 +69,78 @@ resource "aws_cloudfront_distribution" "rails_static_assets" {
 # * add on cache-control header with far future caches for clients,
 #   since MediaConvert won't write those in our outputs in S3 already
 resource "aws_cloudfront_distribution" "derivatives-video" {
-    comment                   = "${terraform.workspace}-derivatives-video S3"
-    enabled                   = true
-    is_ipv6_enabled           = true
+  comment         = "${terraform.workspace}-derivatives-video S3"
+  enabled         = true
+  is_ipv6_enabled = true
 
-    # North America/Europe only, cheaper price class
-    price_class               = "PriceClass_100"
+  # North America/Europe only, cheaper price class
+  price_class = "PriceClass_100"
 
-    origin {
-        domain_name  = "scihist-digicoll-${terraform.workspace}-derivatives-video.s3.${var.aws_region}.amazonaws.com"
-        origin_id    = "${terraform.workspace}-derivatives-video.s3"
+  origin {
+    domain_name = "scihist-digicoll-${terraform.workspace}-derivatives-video.s3.${var.aws_region}.amazonaws.com"
+    origin_id   = "${terraform.workspace}-derivatives-video.s3"
+  }
+
+  # add tag matching bucket name tag used for S3 buckets themselves,
+  # for cost analysis.
+  tags = {
+    "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-derivatives-video.s3"
+    "S3-Bucket-Name"                    = "${local.name_prefix}-derivatives-video"
+  }
+
+
+  default_cache_behavior {
+    allowed_methods = [
+      "GET",
+      "HEAD",
+      "OPTIONS",
+    ]
+    cached_methods = [
+      "GET",
+      "HEAD",
+      "OPTIONS",
+    ]
+
+    # We're already sending mp4 content, adding gzip compression on top
+    # won't help and may hurt.
+    compress = false
+
+    target_origin_id       = "${terraform.workspace}-derivatives-video.s3"
+    viewer_protocol_policy = "https-only"
+
+    # AWS Managed policy for `Managed-CachingOptimizedForUncompressedObjects`
+    cache_policy_id = "b2884449-e4de-46a7-ac36-70bc7f1ddd6d"
+
+    # references policy for far-future Cache-Control header to be added
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.long-time-immutable-cache.id
+  }
+
+
+  restrictions {
+    geo_restriction {
+      locations        = []
+      restriction_type = "none"
     }
+  }
 
-    # add tag matching bucket name tag used for S3 buckets themselves,
-    # for cost analysis.
-    tags                        = {
-        "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-derivatives-video.s3"
-        "S3-Bucket-Name" = "${local.name_prefix}-derivatives-video"
-    }
-
-
-    default_cache_behavior {
-        allowed_methods        = [
-            "GET",
-            "HEAD",
-            "OPTIONS",
-        ]
-        cached_methods         = [
-            "GET",
-            "HEAD",
-            "OPTIONS",
-        ]
-
-        # We're already sending mp4 content, adding gzip compression on top
-        # won't help and may hurt.
-        compress               = false
-
-        target_origin_id       = "${terraform.workspace}-derivatives-video.s3"
-        viewer_protocol_policy = "https-only"
-
-        # AWS Managed policy for `Managed-CachingOptimizedForUncompressedObjects`
-        cache_policy_id        = "b2884449-e4de-46a7-ac36-70bc7f1ddd6d"
-
-        # references policy for far-future Cache-Control header to be added
-        response_headers_policy_id = aws_cloudfront_response_headers_policy.long-time-immutable-cache.id
-    }
-
-
-    restrictions {
-        geo_restriction {
-            locations        = []
-            restriction_type = "none"
-        }
-    }
-
-    viewer_certificate {
-        cloudfront_default_certificate = true
-        minimum_protocol_version       = "TLSv1"
-    }
+  viewer_certificate {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+  }
 }
 
 # Used by any CloudFronts in front of content at "immutable" URLs (random URL
 # that will necessarily change if content does), but where origin (eg S3)
 # is not providing far-future Cache headers -- we add them in.
 resource "aws_cloudfront_response_headers_policy" "long-time-immutable-cache" {
-    name            = "long-time-immutable-cache-${terraform.workspace}"
-    comment         = "far future Cache-Control"
+  name    = "long-time-immutable-cache-${terraform.workspace}"
+  comment = "far future Cache-Control"
 
-    custom_headers_config {
-        items {
-            header   = "Cache-Control"
-            override = false
-            value    = "max-age=31536000, immutable"
-        }
+  custom_headers_config {
+    items {
+      header   = "Cache-Control"
+      override = false
+      value    = "max-age=31536000, immutable"
     }
+  }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -9,11 +9,11 @@ terraform {
 
 provider "aws" {
   profile = local.aws_access_profile
-  region = var.aws_region
+  region  = var.aws_region
 }
 
 provider "aws" {
-  alias = "backup"
+  alias   = "backup"
   profile = local.aws_access_profile
-  region = var.aws_backup_region
+  region  = var.aws_backup_region
 }

--- a/s3.tf
+++ b/s3.tf
@@ -25,78 +25,78 @@
 # Replication only in production.
 #
 resource "aws_s3_bucket" "derivatives" {
-    bucket                      = "${local.name_prefix}-derivatives"
+  bucket = "${local.name_prefix}-derivatives"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "derivatives"
+    "S3-Bucket-Name" = "${local.name_prefix}-derivatives"
+  }
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-derivatives-IT-Rule"
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "derivatives"
-        "S3-Bucket-Name" = "${local.name_prefix}-derivatives"
+    transition {
+      days          = 30
+      storage_class = "INTELLIGENT_TIERING"
     }
+  }
 
-    cors_rule {
-        allowed_headers = [
-            "*",
-        ]
-        allowed_methods = [
-            "GET",
-        ]
-        allowed_origins = [
-            "*",
-        ]
-        expose_headers  = []
-        max_age_seconds = 43200
-    }
+  # only Enabled for production.
+  dynamic "replication_configuration" {
+    // hacky way to make this conditional, once and only once on production.
+    for_each = terraform.workspace == "production" ? [1] : []
+    content {
+      # we're not controlling the IAM role with terraform, so we just hardcode it for now.
+      role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
+      rules {
+        id       = "Backup"
+        priority = 0
+        status   = "Enabled"
 
-        noncurrent_version_expiration {
-            days = 30
+        destination {
+          bucket = one(aws_s3_bucket.derivatives_backup).arn
         }
+      }
     }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-derivatives-IT-Rule"
+  }
 
-        transition {
-            days          = 30
-            storage_class = "INTELLIGENT_TIERING"
-        }
-    }
-
-    # only Enabled for production.
-    dynamic "replication_configuration" {
-        // hacky way to make this conditional, once and only once on production.
-        for_each = terraform.workspace == "production" ? [1] : []
-        content {
-            # we're not controlling the IAM role with terraform, so we just hardcode it for now.
-            role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
-
-            rules {
-                id       = "Backup"
-                priority = 0
-                status   = "Enabled"
-
-                destination {
-                    bucket = one(aws_s3_bucket.derivatives_backup).arn
-                }
-            }
-        }
-    }
-
-    versioning {
-        enabled    = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_policy" "derivatives" {
-    bucket = aws_s3_bucket.derivatives.id
-    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.derivatives.id })
+  bucket = aws_s3_bucket.derivatives.id
+  policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name : aws_s3_bucket.derivatives.id })
 }
 
 # Video derivatives, expected to be mainly/only HLS. Set up in a separate bucket from
@@ -109,58 +109,58 @@ resource "aws_s3_bucket_policy" "derivatives" {
 #   derivatives bucket. In this case, signed URLs wouldn't work for HLS files,
 #   as the manifest files have references to static urls in them too.
 resource "aws_s3_bucket" "derivatives_video" {
-    bucket                      = "${local.name_prefix}-derivatives-video"
+  bucket = "${local.name_prefix}-derivatives-video"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "derivatives"
+    "S3-Bucket-Name" = "${local.name_prefix}-derivatives-video"
+  }
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-derivatives-IT-Rule"
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "derivatives"
-        "S3-Bucket-Name" = "${local.name_prefix}-derivatives-video"
+    transition {
+      days          = 30
+      storage_class = "INTELLIGENT_TIERING"
     }
+  }
 
-    cors_rule {
-        allowed_headers = [
-            "*",
-        ]
-        allowed_methods = [
-            "GET",
-        ]
-        allowed_origins = [
-            "*",
-        ]
-        expose_headers  = []
-        max_age_seconds = 43200
-    }
-
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-
-        noncurrent_version_expiration {
-            days = 30
-        }
-    }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-derivatives-IT-Rule"
-
-        transition {
-            days          = 30
-            storage_class = "INTELLIGENT_TIERING"
-        }
-    }
-
-    versioning {
-        enabled    = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_policy" "derivatives-video" {
-    bucket = aws_s3_bucket.derivatives_video.id
-    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.derivatives_video.id })
+  bucket = aws_s3_bucket.derivatives_video.id
+  policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name : aws_s3_bucket.derivatives_video.id })
 }
 
 
@@ -169,79 +169,79 @@ resource "aws_s3_bucket_policy" "derivatives-video" {
 #
 # Replication only in production.
 resource "aws_s3_bucket" "dzi" {
-    bucket                      = "${local.name_prefix}-dzi"
+  bucket = "${local.name_prefix}-dzi"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "dzi"
+    "S3-Bucket-Name" = "${local.name_prefix}-dzi"
+  }
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-dzi-IT-Rule"
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "dzi"
-        "S3-Bucket-Name" = "${local.name_prefix}-dzi"
+    transition {
+      days          = 30
+      storage_class = "INTELLIGENT_TIERING"
     }
+  }
 
-    cors_rule {
-      allowed_headers = [
-          "*",
-      ]
-      allowed_methods = [
-          "GET",
-      ]
-      allowed_origins = [
-          "*",
-      ]
-      expose_headers  = []
-      max_age_seconds = 43200
-    }
+  # only Enabled for production.
+  dynamic "replication_configuration" {
+    // hacky way to make this conditional, once and only once on production.
+    for_each = terraform.workspace == "production" ? [1] : []
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
+    content {
+      # we're not controlling the IAM role with terraform, so we just hardcode it for now.
+      role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
 
-        noncurrent_version_expiration {
-            days = 30
+      rules {
+        id       = "Backup"
+        priority = 0
+        status   = "Enabled"
+
+        destination {
+          bucket = one(aws_s3_bucket.dzi_backup).arn
         }
+      }
     }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-dzi-IT-Rule"
+  }
 
-        transition {
-            days          = 30
-            storage_class = "INTELLIGENT_TIERING"
-        }
-    }
-
-    # only Enabled for production.
-    dynamic "replication_configuration" {
-        // hacky way to make this conditional, once and only once on production.
-        for_each = terraform.workspace == "production" ? [1] : []
-
-        content {
-            # we're not controlling the IAM role with terraform, so we just hardcode it for now.
-            role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
-
-            rules {
-                id       = "Backup"
-                priority = 0
-                status   = "Enabled"
-
-                destination {
-                    bucket = one(aws_s3_bucket.dzi_backup).arn
-                }
-            }
-        }
-    }
-
-    versioning {
-        enabled    = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_policy" "dzi" {
-    bucket = aws_s3_bucket.dzi.id
-    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.dzi.id })
+  bucket = aws_s3_bucket.dzi.id
+  policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name : aws_s3_bucket.dzi.id })
 }
 
 
@@ -255,60 +255,60 @@ resource "aws_s3_bucket_policy" "dzi" {
 # ingest by app.
 #
 resource "aws_s3_bucket" "ingest_mount" {
-    bucket                      = "${local.name_prefix}-ingest-mount"
+  bucket = "${local.name_prefix}-ingest-mount"
 
-    lifecycle {
-      prevent_destroy           = true
-    }
+  lifecycle {
+    prevent_destroy = true
+  }
 
-    tags                      = {
-        "service" = local.service_tag
-        "use"     = "upload"
-        "S3-Bucket-Name" = "${local.name_prefix}-ingest-mount"
-    }
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "upload"
+    "S3-Bucket-Name" = "${local.name_prefix}-ingest-mount"
+  }
 
-    cors_rule {
-        allowed_headers = [
-            "Authorization",
-            "x-amz-date",
-            "x-amz-content-sha256",
-            "content-type",
-        ]
-        allowed_methods = [
-            "GET",
-            "POST",
-            "PUT",
-        ]
-        allowed_origins = [
-            "*",
-        ]
-        expose_headers  = [
-            "ETag",
-        ]
-        max_age_seconds = 3000
-    }
+  cors_rule {
+    allowed_headers = [
+      "Authorization",
+      "x-amz-date",
+      "x-amz-content-sha256",
+      "content-type",
+    ]
+    allowed_methods = [
+      "GET",
+      "POST",
+      "PUT",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers = [
+      "ETag",
+    ]
+    max_age_seconds = 3000
+  }
 
-    lifecycle_rule {
-        enabled                                = false
-        id                                     = "Expire files"
-        expiration {
-            days                         = 30
-            expired_object_delete_marker = false
-        }
+  lifecycle_rule {
+    enabled = false
+    id      = "Expire files"
+    expiration {
+      days                         = 30
+      expired_object_delete_marker = false
     }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-ingest-mount-IA-Rule"
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-ingest-mount-IA-Rule"
 
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
+  }
 
-    versioning {
-        enabled    = false
-    }
+  versioning {
+    enabled = false
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "ingest_mount" {
@@ -327,41 +327,41 @@ resource "aws_s3_bucket_public_access_block" "ingest_mount" {
 # lifecycle rules to delete ones that haven't been accessed in a while.
 #
 # Doesn't need a public policy cause we just set public-read ACLs on individual objects.
-resource "aws_s3_bucket"  "ondemand_derivatives" {
-    bucket                      = "${local.name_prefix}-ondemand-derivatives"
+resource "aws_s3_bucket" "ondemand_derivatives" {
+  bucket = "${local.name_prefix}-ondemand-derivatives"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "cache"
+    "S3-Bucket-Name" = "${local.name_prefix}-ondemand-derivatives"
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire files"
+
+    expiration {
+      days                         = 20
+      expired_object_delete_marker = false
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-ondemand-derivatives-IA-Rule"
 
-    tags                        = {
-          "service" = local.service_tag
-          "use"     = "cache"
-          "S3-Bucket-Name" = "${local.name_prefix}-ondemand-derivatives"
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
+  }
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire files"
-
-        expiration {
-            days                         = 20
-            expired_object_delete_marker = false
-        }
-    }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-ondemand-derivatives-IA-Rule"
-
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
-    }
-
-    versioning {
-        enabled    = false
-    }
+  versioning {
+    enabled = false
+  }
 }
 
 
@@ -375,64 +375,64 @@ resource "aws_s3_bucket"  "ondemand_derivatives" {
 # Replication rule only for production.
 #
 resource "aws_s3_bucket" "originals" {
-    bucket                      = "${local.name_prefix}-originals"
+  bucket = "${local.name_prefix}-originals"
 
-    lifecycle {
-      prevent_destroy           = true
-    }
+  lifecycle {
+    prevent_destroy = true
+  }
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "originals"
-        "S3-Bucket-Name" = "${local.name_prefix}-originals"
-    }
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "originals"
+    "S3-Bucket-Name" = "${local.name_prefix}-originals"
+  }
 
-    # only Enabled for production.
-    dynamic "replication_configuration" {
-        // hacky way to make this conditional, once and only once on production.
-        for_each = terraform.workspace == "production" ? [1] : []
+  # only Enabled for production.
+  dynamic "replication_configuration" {
+    // hacky way to make this conditional, once and only once on production.
+    for_each = terraform.workspace == "production" ? [1] : []
 
-        content {
-            # we're not controlling the IAM role with terraform, so we just hardcode it for now.
-            role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
+    content {
+      # we're not controlling the IAM role with terraform, so we just hardcode it for now.
+      role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
 
-            rules {
-                id       = "Backup"
-                priority = 0
-                status   = "Enabled"
+      rules {
+        id       = "Backup"
+        priority = 0
+        status   = "Enabled"
 
-                destination {
-                    bucket = one(aws_s3_bucket.originals_backup).arn
-                }
-            }
+        destination {
+          bucket = one(aws_s3_bucket.originals_backup).arn
         }
+      }
     }
+  }
 
-    # logging {
-    #    target_bucket = "chf-logs"
-    #    target_prefix = "s3_server_access_${terraform.workspace}_originals/"
-    # }
+  # logging {
+  #    target_bucket = "chf-logs"
+  #    target_prefix = "s3_server_access_${terraform.workspace}_originals/"
+  # }
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-        noncurrent_version_expiration {
-            days = 30
-        }
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-originals-IT-Rule"
-        transition {
-            days          = 30
-            storage_class = "INTELLIGENT_TIERING"
-        }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-originals-IT-Rule"
+    transition {
+      days          = 30
+      storage_class = "INTELLIGENT_TIERING"
     }
+  }
 
-    versioning {
-        enabled    = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "originals" {
@@ -452,64 +452,64 @@ resource "aws_s3_bucket_public_access_block" "originals" {
 # Replication rule only for production.
 #
 resource "aws_s3_bucket" "originals_video" {
-    bucket                      = "${local.name_prefix}-originals-video"
+  bucket = "${local.name_prefix}-originals-video"
 
-    lifecycle {
-      prevent_destroy           = true
-    }
+  lifecycle {
+    prevent_destroy = true
+  }
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "originals"
-        "S3-Bucket-Name" = "${local.name_prefix}-originals-video"
-    }
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "originals"
+    "S3-Bucket-Name" = "${local.name_prefix}-originals-video"
+  }
 
-    # only Enabled for production.
-    dynamic "replication_configuration" {
-        // hacky way to make this conditional, once and only once on production.
-        for_each = terraform.workspace == "production" ? [1] : []
+  # only Enabled for production.
+  dynamic "replication_configuration" {
+    // hacky way to make this conditional, once and only once on production.
+    for_each = terraform.workspace == "production" ? [1] : []
 
-        content {
-            # we're not controlling the IAM role with terraform, so we just hardcode it for now.
-            role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
+    content {
+      # we're not controlling the IAM role with terraform, so we just hardcode it for now.
+      role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
 
-            rules {
-                id       = "Backup"
-                priority = 0
-                status   = "Enabled"
+      rules {
+        id       = "Backup"
+        priority = 0
+        status   = "Enabled"
 
-                destination {
-                    bucket = one(aws_s3_bucket.originals_video_backup).arn
-                }
-            }
+        destination {
+          bucket = one(aws_s3_bucket.originals_video_backup).arn
         }
+      }
     }
+  }
 
-    # logging {
-    #    target_bucket = "chf-logs"
-    #    target_prefix = "s3_server_access_${terraform.workspace}_originals_video/"
-    # }
+  # logging {
+  #    target_bucket = "chf-logs"
+  #    target_prefix = "s3_server_access_${terraform.workspace}_originals_video/"
+  # }
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-        noncurrent_version_expiration {
-            days = 30
-        }
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-originals-video-IT-Rule"
-        transition {
-            days          = 30
-            storage_class = "INTELLIGENT_TIERING"
-        }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-originals-video-IT-Rule"
+    transition {
+      days          = 30
+      storage_class = "INTELLIGENT_TIERING"
     }
+  }
 
-    versioning {
-        enabled    = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "originals_video" {
@@ -527,26 +527,26 @@ resource "aws_s3_bucket_public_access_block" "originals_video" {
 # A public bucket intended for a variety of uses. Does not have versioning turned on at present.
 #
 resource "aws_s3_bucket" "public" {
-    bucket                      = "${local.name_prefix}-public"
+  bucket = "${local.name_prefix}-public"
 
-    lifecycle {
-      prevent_destroy           = true
-    }
+  lifecycle {
+    prevent_destroy = true
+  }
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "general_public"
-        "S3-Bucket-Name" = "${local.name_prefix}-public"
-    }
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "general_public"
+    "S3-Bucket-Name" = "${local.name_prefix}-public"
+  }
 
-    versioning {
-        enabled    = false
-    }
+  versioning {
+    enabled = false
+  }
 }
 
 resource "aws_s3_bucket_policy" "public" {
-    bucket = aws_s3_bucket.public.id
-    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.public.id })
+  bucket = aws_s3_bucket.public.id
+  policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name : aws_s3_bucket.public.id })
 }
 
 
@@ -556,62 +556,62 @@ resource "aws_s3_bucket_policy" "public" {
 # A bucket to which our app's in-browser javascript uploads files to be ingested, so the
 # back-end app can get them. Should NOT be public. Needs CORS tags to allow JS upload.
 #
-resource "aws_s3_bucket"  "uploads" {
-    bucket = "${local.name_prefix}-uploads"
+resource "aws_s3_bucket" "uploads" {
+  bucket = "${local.name_prefix}-uploads"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "upload"
+    "S3-Bucket-Name" = "${local.name_prefix}-uploads"
+  }
+
+  cors_rule {
+    allowed_headers = [
+      "Authorization",
+      "x-amz-date",
+      "x-amz-content-sha256",
+      "content-type",
+    ]
+    allowed_methods = [
+      "GET",
+      "POST",
+      "PUT",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers = [
+      "ETag",
+    ]
+    max_age_seconds = 3000
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire files"
+
+    expiration {
+      days                         = 30
+      expired_object_delete_marker = false
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-uploads-IA-Rule"
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "upload"
-        "S3-Bucket-Name" = "${local.name_prefix}-uploads"
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
+  }
 
-    cors_rule {
-        allowed_headers = [
-            "Authorization",
-            "x-amz-date",
-            "x-amz-content-sha256",
-            "content-type",
-        ]
-        allowed_methods = [
-            "GET",
-            "POST",
-            "PUT",
-        ]
-        allowed_origins = [
-            "*",
-        ]
-        expose_headers  = [
-            "ETag",
-        ]
-        max_age_seconds = 3000
-    }
-
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire files"
-
-        expiration {
-            days                         = 30
-            expired_object_delete_marker = false
-        }
-    }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-uploads-IA-Rule"
-
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
-    }
-
-    versioning {
-        enabled    = false
-    }
+  versioning {
+    enabled = false
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "uploads" {
@@ -631,190 +631,190 @@ resource "aws_s3_bucket_public_access_block" "uploads" {
 #
 ###
 
-resource "aws_s3_bucket"  "derivatives_backup" {
-    count = "${terraform.workspace == "production" ? 1 : 0}"
-    provider = aws.backup
+resource "aws_s3_bucket" "derivatives_backup" {
+  count    = terraform.workspace == "production" ? 1 : 0
+  provider = aws.backup
 
-    bucket = "${local.name_prefix}-derivatives-backup"
+  bucket = "${local.name_prefix}-derivatives-backup"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "derivatives"
+    "S3-Bucket-Name" = "${local.name_prefix}-derivatives-backup"
+  }
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-${terraform.workspace}-derivatives-backup-IA-Rule"
 
-    tags                        = {
-        "service" = local.service_tag
-        "use"     = "derivatives"
-        "S3-Bucket-Name" = "${local.name_prefix}-derivatives-backup"
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
+  }
 
-    cors_rule {
-        allowed_headers = [
-            "*",
-        ]
-        allowed_methods = [
-            "GET",
-        ]
-        allowed_origins = [
-            "*",
-        ]
-        expose_headers  = []
-        max_age_seconds = 43200
-    }
-
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-
-        noncurrent_version_expiration {
-            days = 30
-        }
-    }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-${terraform.workspace}-derivatives-backup-IA-Rule"
-
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
-    }
-
-    versioning {
-        enabled    = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_policy" "derivatives_backup" {
-    count = "${terraform.workspace == "production" ? 1 : 0}"
-    provider = aws.backup
+  count    = terraform.workspace == "production" ? 1 : 0
+  provider = aws.backup
 
-    bucket = aws_s3_bucket.derivatives_backup[0].id
-    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.derivatives_backup[0].id })
+  bucket = aws_s3_bucket.derivatives_backup[0].id
+  policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name : aws_s3_bucket.derivatives_backup[0].id })
 }
 
 
-resource "aws_s3_bucket"  "dzi_backup" {
-    count = "${terraform.workspace == "production" ? 1 : 0}"
-    provider = aws.backup
+resource "aws_s3_bucket" "dzi_backup" {
+  count    = terraform.workspace == "production" ? 1 : 0
+  provider = aws.backup
 
-    bucket = "${local.name_prefix}-dzi-backup"
+  bucket = "${local.name_prefix}-dzi-backup"
 
-    lifecycle {
-      prevent_destroy           = true
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    "service"        = "kithe"
+    "use"            = "dzi"
+    "S3-Bucket-Name" = "${local.name_prefix}-dzi-backup"
+  }
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "scihist-digicoll-production-dzi-backup-IA-Rule"
 
-    tags                        = {
-        "service" = "kithe"
-        "use"     = "dzi"
-        "S3-Bucket-Name" = "${local.name_prefix}-dzi-backup"
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
-
-    cors_rule {
-        allowed_headers = [
-            "*",
-        ]
-        allowed_methods = [
-            "GET",
-        ]
-        allowed_origins = [
-            "*",
-        ]
-        expose_headers  = []
-        max_age_seconds = 43200
-    }
-
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-
-        noncurrent_version_expiration {
-            days = 30
-        }
-    }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "scihist-digicoll-production-dzi-backup-IA-Rule"
-
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
-    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "dzi_backup" {
-    count = "${terraform.workspace == "production" ? 1 : 0}"
-    provider = aws.backup
+  count    = terraform.workspace == "production" ? 1 : 0
+  provider = aws.backup
 
-    bucket = aws_s3_bucket.dzi_backup[0].id
-    policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name: aws_s3_bucket.dzi_backup[0].id })
+  bucket = aws_s3_bucket.dzi_backup[0].id
+  policy = templatefile("templates/s3_public_read_policy.tftpl", { bucket_name : aws_s3_bucket.dzi_backup[0].id })
 }
 
-resource "aws_s3_bucket"  "originals_backup" {
-    count = "${terraform.workspace == "production" ? 1 : 0}"
-    provider = aws.backup
+resource "aws_s3_bucket" "originals_backup" {
+  count    = terraform.workspace == "production" ? 1 : 0
+  provider = aws.backup
 
-    bucket = "${local.name_prefix}-originals-backup"
+  bucket = "${local.name_prefix}-originals-backup"
 
-    tags                        = {
-        "service" = "kithe"
-        "use"     = "originals"
-        "S3-Bucket-Name" = "${local.name_prefix}-originals-backup"
+  tags = {
+    "service"        = "kithe"
+    "use"            = "originals"
+    "S3-Bucket-Name" = "${local.name_prefix}-originals-backup"
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "Scihist-digicoll-production-originals-backup_Lifecycle"
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-
-        noncurrent_version_expiration {
-            days = 30
-        }
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Scihist-digicoll-production-originals-backup_Lifecycle"
-
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
-    }
-    versioning {
-        enabled    = true
-    }
+  }
+  versioning {
+    enabled = true
+  }
 }
 
-resource "aws_s3_bucket"  "originals_video_backup" {
-    count = "${terraform.workspace == "production" ? 1 : 0}"
-    provider = aws.backup
+resource "aws_s3_bucket" "originals_video_backup" {
+  count    = terraform.workspace == "production" ? 1 : 0
+  provider = aws.backup
 
-    bucket = "${local.name_prefix}-originals-video-backup"
+  bucket = "${local.name_prefix}-originals-video-backup"
 
-    tags                        = {
-        "service" = "kithe"
-        "use"     = "originals"
-        "S3-Bucket-Name" = "${local.name_prefix}-originals-video-backup"
+  tags = {
+    "service"        = "kithe"
+    "use"            = "originals"
+    "S3-Bucket-Name" = "${local.name_prefix}-originals-video-backup"
+  }
+
+  lifecycle_rule {
+    enabled = true
+    id      = "Expire previous files"
+
+    noncurrent_version_expiration {
+      days = 30
     }
+  }
+  lifecycle_rule {
+    enabled = true
+    id      = "${local.name_prefix}-originals-video-backup_Lifecycle"
 
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "Expire previous files"
-
-        noncurrent_version_expiration {
-            days = 30
-        }
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
-    lifecycle_rule {
-        enabled                                = true
-        id                                     = "${local.name_prefix}-originals-video-backup_Lifecycle"
-
-        transition {
-            days          = 30
-            storage_class = "STANDARD_IA"
-        }
-    }
-    versioning {
-        enabled    = true
-    }
+  }
+  versioning {
+    enabled = true
+  }
 }
 

--- a/shared_state_s3.tf
+++ b/shared_state_s3.tf
@@ -14,12 +14,12 @@
 resource "aws_s3_bucket" "terraform_state" {
   bucket = "scihist-digicoll-terraform-state"
 
-  count = "${terraform.workspace == "production" ? 1 : 0}"
+  count = terraform.workspace == "production" ? 1 : 0
 
-  tags                        = {
-      "service" = local.service_tag
-      "use"     = "terraform"
-       "S3-Bucket-Name" = "scihist-digicoll-terraform-state"
+  tags = {
+    "service"        = local.service_tag
+    "use"            = "terraform"
+    "S3-Bucket-Name" = "scihist-digicoll-terraform-state"
   }
 
   # Enable versioning so we can see the full revision history of our
@@ -41,7 +41,7 @@ resource "aws_s3_bucket" "terraform_state" {
 resource "aws_s3_bucket_public_access_block" "terraform_state" {
   bucket = aws_s3_bucket.terraform_state[0].id
 
-  count = "${terraform.workspace == "production" ? 1 : 0}"
+  count = terraform.workspace == "production" ? 1 : 0
 
   block_public_acls       = true
   block_public_policy     = true
@@ -50,16 +50,16 @@ resource "aws_s3_bucket_public_access_block" "terraform_state" {
 }
 
 resource "aws_dynamodb_table" "terraform_state_locks" {
-  name         = "scihist-digicoll-terraform-state-locks"
+  name = "scihist-digicoll-terraform-state-locks"
 
-  count = "${terraform.workspace == "production" ? 1 : 0}"
+  count = terraform.workspace == "production" ? 1 : 0
 
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "LockID"
 
-  tags                        = {
-      "service" = local.service_tag
-      "use"     = "terraform"
+  tags = {
+    "service" = local.service_tag
+    "use"     = "terraform"
   }
 
   attribute {

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,10 @@
 # means, including a .tvvars file, the terraform command line, or special
 # TV_VARS_* ENV variables. https://www.terraform.io/docs/language/values/variables.html
 
-variable aws_region {
+variable "aws_region" {
   default = "us-east-1"
 }
 
-variable aws_backup_region {
+variable "aws_backup_region" {
   default = "us-west-2"
 }


### PR DESCRIPTION
This is JUST the changes introduced by:
terraform fmt *.tf .

This will save us a lot of agita as we progressively update the config files to work with the latest version of the AWS terraform provider.

Aside from many whitespace changes:

- it puts variable names in quotes as they are declared;
- it simplifies the expression we assign to our `count` variable to `terraform.workspace == "production" ? 1 : 0`

Note: [Terraform automatically converts number and bool values](https://developer.hashicorp.com/terraform/language/expressions/types#15): `15` converts to `"15"`, and vice-versa.
