### PR TITLE
Adding a cloudfront distribution for the derivatives bucket.

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -129,6 +129,11 @@ resource "aws_cloudfront_distribution" "derivatives-video" {
   }
 }
 
+
+# Cloudfront distribution for our derivatives bucket.
+# This includes asset derivatives but also combined audio derivatives, which the
+# Oral Histories team uses for OHMS transcripts. This last use case is the primary impetus for
+# having this distribution.
 resource "aws_cloudfront_distribution" "derivatives" {
 
   comment         = "${terraform.workspace}-derivatives S3"
@@ -164,7 +169,7 @@ resource "aws_cloudfront_distribution" "derivatives" {
       "HEAD"
     ]
 
-    # We're already sending mp4 content, adding gzip compression on top
+    # These derivs are already compressed. Adding gzip compression on top
     # won't help and may hurt.
     compress = false
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -137,7 +137,6 @@ resource "aws_cloudfront_distribution" "derivatives-video" {
 resource "aws_cloudfront_distribution" "derivatives" {
 
   comment         = "${terraform.workspace}-derivatives S3"
-  http_version    = "http2"
   enabled         = true
   is_ipv6_enabled = true
 
@@ -145,10 +144,8 @@ resource "aws_cloudfront_distribution" "derivatives" {
   price_class = "PriceClass_100"
 
   origin {
-    connection_attempts = 3
-    connection_timeout  = 10
     domain_name         = "scihist-digicoll-${terraform.workspace}-derivatives.s3.${var.aws_region}.amazonaws.com"
-    origin_id           = "scihist-digicoll-${terraform.workspace}-derivatives.s3.${var.aws_region}.amazonaws.com"
+    origin_id           = "${terraform.workspace}-derivatives.s3"
   }
 
   # add tag matching bucket name tag used for S3 buckets themselves,
@@ -162,18 +159,20 @@ resource "aws_cloudfront_distribution" "derivatives" {
   default_cache_behavior {
     allowed_methods = [
       "GET",
-      "HEAD"
+      "HEAD",
+      "OPTIONS"
     ]
     cached_methods = [
       "GET",
-      "HEAD"
+      "HEAD",
+      "OPTIONS"
     ]
 
     # These derivs are already compressed. Adding gzip compression on top
     # won't help and may hurt.
     compress = false
 
-    target_origin_id       = "scihist-digicoll-${terraform.workspace}-derivatives.s3.${var.aws_region}.amazonaws.com"
+    target_origin_id       = "${terraform.workspace}-derivatives.s3"
     viewer_protocol_policy = "https-only"
 
     # AWS Managed policy for `Managed-CachingOptimizedForUncompressedObjects`

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -129,6 +129,71 @@ resource "aws_cloudfront_distribution" "derivatives-video" {
   }
 }
 
+resource "aws_cloudfront_distribution" "derivatives" {
+
+  comment         = "${terraform.workspace}-derivatives S3"
+  http_version    = "http2"
+  enabled         = true
+  is_ipv6_enabled = true
+
+  # North America/Europe only, cheaper price class
+  price_class = "PriceClass_100"
+
+  origin {
+    connection_attempts = 3
+    connection_timeout  = 10
+    domain_name         = "scihist-digicoll-${terraform.workspace}-derivatives.s3.${var.aws_region}.amazonaws.com"
+    origin_id           = "scihist-digicoll-${terraform.workspace}-derivatives.s3.${var.aws_region}.amazonaws.com"
+  }
+
+  # add tag matching bucket name tag used for S3 buckets themselves,
+  # for cost analysis.
+  tags = {
+    "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-derivatives.s3"
+    "S3-Bucket-Name"                    = "${local.name_prefix}-derivatives"
+  }
+
+
+  default_cache_behavior {
+    allowed_methods = [
+      "GET",
+      "HEAD"
+    ]
+    cached_methods = [
+      "GET",
+      "HEAD"
+    ]
+
+    # We're already sending mp4 content, adding gzip compression on top
+    # won't help and may hurt.
+    compress = false
+
+    target_origin_id       = "scihist-digicoll-${terraform.workspace}-derivatives.s3.${var.aws_region}.amazonaws.com"
+    viewer_protocol_policy = "https-only"
+
+    # AWS Managed policy for `Managed-CachingOptimizedForUncompressedObjects`
+    cache_policy_id = "b2884449-e4de-46a7-ac36-70bc7f1ddd6d"
+
+    # references policy for far-future Cache-Control header to be added
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.long-time-immutable-cache.id
+  }
+
+
+  restrictions {
+    geo_restriction {
+      locations        = []
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+  }
+
+}
+
+
 # Used by any CloudFronts in front of content at "immutable" URLs (random URL
 # that will necessarily change if content does), but where origin (eg S3)
 # is not providing far-future Cache headers -- we add them in.


### PR DESCRIPTION
This describes a cloudfront distribution for our derivatives bucket.
The distribution [already exists for the staging AWS derivs bucket](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home?region=ca-central-1#/distributions/E19RS5U2S16YNT).

If you check out this branch, make sure you're in the staging terraform environment, and do:
`terraform import aws_cloudfront_distribution.derivatives E19RS5U2S16YNT`
you should get:
```
Import successful!
The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```
`terraform plan` should then yield:
[...]
`No changes. Your infrastructure matches the configuration.`

Ref https://github.com/sciencehistory/terraform_scihist_digicoll/issues/31