### PR TITLE
removing the offending versioning block

### DIFF
--- a/shared_state_s3.tf
+++ b/shared_state_s3.tf
@@ -21,13 +21,16 @@ resource "aws_s3_bucket" "terraform_state" {
     "use"            = "terraform"
     "S3-Bucket-Name" = "scihist-digicoll-terraform-state"
   }
+}
 
+resource "aws_s3_bucket_versioning" "terraform_state" {
   # Enable versioning so we can see the full revision history of our
   # state files
-  versioning {
-    enabled = true
+  bucket = aws_s3_bucket.terraform_state[0].id
+  count  = terraform.workspace == "production" ? 1 : 0
+  versioning_configuration {
+    status = "Enabled"
   }
-
 }
 
 resource "aws_s3_bucket_public_access_block" "terraform_state" {
@@ -40,6 +43,8 @@ resource "aws_s3_bucket_public_access_block" "terraform_state" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
   bucket = aws_s3_bucket.terraform_state[0].id


### PR DESCRIPTION
Adding an `aws_s3_bucket_versioning` block for the shared state bucket to shared_state.tf  .
Should have been part of an earlier PR (#40 ).
Ref #38 .