### PR TITLE
Explicitly specify the provider for the new configuration items for backup buckets

### DIFF
--- a/bucket_derivatives_backup.tf
+++ b/bucket_derivatives_backup.tf
@@ -30,8 +30,9 @@ resource "aws_s3_bucket_policy" "derivatives_backup" {
 }
 
 resource "aws_s3_bucket_cors_configuration" "derivatives_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.derivatives_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.derivatives_backup[0].id
+  provider = aws.backup
 
   cors_rule {
     allowed_headers = [
@@ -49,8 +50,9 @@ resource "aws_s3_bucket_cors_configuration" "derivatives_backup" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "derivatives_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.derivatives_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.derivatives_backup[0].id
+  provider = aws.backup
 
   rule {
     status = "Enabled"
@@ -72,16 +74,20 @@ resource "aws_s3_bucket_lifecycle_configuration" "derivatives_backup" {
 }
 
 resource "aws_s3_bucket_versioning" "derivatives_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.derivatives_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.derivatives_backup[0].id
+  provider = aws.backup
+
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "derivatives_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.derivatives_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.derivatives_backup[0].id
+  provider = aws.backup
+
 
   rule {
     bucket_key_enabled = false

--- a/bucket_dzi_backup.tf
+++ b/bucket_dzi_backup.tf
@@ -31,8 +31,9 @@ resource "aws_s3_bucket_policy" "dzi_backup" {
 }
 
 resource "aws_s3_bucket_cors_configuration" "dzi_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.dzi_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.dzi_backup[0].id
+  provider = aws.backup
 
   cors_rule {
     allowed_headers = [
@@ -50,8 +51,9 @@ resource "aws_s3_bucket_cors_configuration" "dzi_backup" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "dzi_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.dzi_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.dzi_backup[0].id
+  provider = aws.backup
 
   rule {
     status = "Enabled"
@@ -73,8 +75,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "dzi_backup" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "dzi_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.dzi_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.dzi_backup[0].id
+  provider = aws.backup
 
   rule {
     bucket_key_enabled = false

--- a/bucket_originals_backup.tf
+++ b/bucket_originals_backup.tf
@@ -22,8 +22,9 @@ resource "aws_s3_bucket" "originals_backup" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "originals_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.originals_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.originals_backup[0].id
+  provider = aws.backup
 
   rule {
     status = "Enabled"
@@ -45,16 +46,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "originals_backup" {
 }
 
 resource "aws_s3_bucket_versioning" "originals_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.originals_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.originals_backup[0].id
+  provider = aws.backup
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "originals_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.originals_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.originals_backup[0].id
+  provider = aws.backup
 
   rule {
     bucket_key_enabled = false

--- a/bucket_originals_video_backup.tf
+++ b/bucket_originals_video_backup.tf
@@ -22,8 +22,9 @@ resource "aws_s3_bucket" "originals_video_backup" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "originals_video_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.originals_video_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.originals_video_backup[0].id
+  provider = aws.backup
 
   rule {
     status = "Enabled"
@@ -46,16 +47,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "originals_video_backup" {
 }
 
 resource "aws_s3_bucket_versioning" "originals_video_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.originals_video_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.originals_video_backup[0].id
+  provider = aws.backup
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "originals_video_backup" {
-  count  = terraform.workspace == "production" ? 1 : 0
-  bucket = aws_s3_bucket.originals_video_backup[0].id
+  count    = terraform.workspace == "production" ? 1 : 0
+  bucket   = aws_s3_bucket.originals_video_backup[0].id
+  provider = aws.backup
   rule {
     bucket_key_enabled = false
     apply_server_side_encryption_by_default {


### PR DESCRIPTION
Ref #28 
For items like `resource "aws_s3_bucket_lifecycle_configuration" "originals_video_backup" `, you need to specify the provider, as Terraform won't infer it from the bucket's provider.

