### PR TITLE
Add new-style aws s3 bucket replication configuration

### DIFF
--- a/bucket_derivatives.tf
+++ b/bucket_derivatives.tf
@@ -8,7 +8,8 @@ resource "aws_s3_bucket" "derivatives" {
     # Can remove this ignore_changes after we move to AWS Provider 4.x
     ignore_changes = [
       cors_rule,
-      lifecycle_rule
+      lifecycle_rule,
+      replication_configuration
     ]
   }
 
@@ -17,44 +18,22 @@ resource "aws_s3_bucket" "derivatives" {
     "use"            = "derivatives"
     "S3-Bucket-Name" = "${local.name_prefix}-derivatives"
   }
-
-  # only Enabled for production.
-  # dynamic "replication_configuration" {
-  #   // hacky way to make this conditional, once and only once on production.
-  #   for_each = terraform.workspace == "production" ? [1] : []
-  #   content {
-  #     # we're not controlling the IAM role with terraform, so we just hardcode it for now.
-  #     role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
-
-  #     rules {
-  #       id       = "Backup"
-  #       priority = 0
-  #       status   = "Enabled"
-
-  #       destination {
-  #         bucket = one(aws_s3_bucket.derivatives_backup).arn
-  #       }
-  #     }
-  #   }
-  # }
-
 }
 
 resource "aws_s3_bucket_replication_configuration" "derivatives" {
-  # only enabled for production.
+  count  = terraform.workspace == "production" ? 1 : 0
   bucket = aws_s3_bucket.derivatives.id
-  role   = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
+  # we're not controlling the IAM role with terraform, so we just hardcode it for now.
+  role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
   rule {
     id       = "Backup"
     priority = 0
-    status   = terraform.workspace == "production" ? "Enabled" : "Disabled"
-
+    status   = "Enabled"
     destination {
-      bucket = one(aws_s3_bucket.derivatives_backup).arn
+      bucket = aws_s3_bucket.derivatives_backup[0].arn
     }
   }
 }
-
 
 resource "aws_s3_bucket_policy" "derivatives" {
   bucket = aws_s3_bucket.derivatives.id

--- a/bucket_originals.tf
+++ b/bucket_originals.tf
@@ -13,7 +13,8 @@ resource "aws_s3_bucket" "originals" {
     # Can remove this ignore_changes after we move to AWS Provider 4.x
     ignore_changes = [
       cors_rule,
-      lifecycle_rule
+      lifecycle_rule,
+      replication_configuration
     ]
   }
 
@@ -23,32 +24,28 @@ resource "aws_s3_bucket" "originals" {
     "S3-Bucket-Name" = "${local.name_prefix}-originals"
   }
 
-  # only Enabled for production.
-  dynamic "replication_configuration" {
-    // hacky way to make this conditional, once and only once on production.
-    for_each = terraform.workspace == "production" ? [1] : []
-
-    content {
-      # we're not controlling the IAM role with terraform, so we just hardcode it for now.
-      role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
-
-      rules {
-        id       = "Backup"
-        priority = 0
-        status   = "Enabled"
-
-        destination {
-          bucket = one(aws_s3_bucket.originals_backup).arn
-        }
-      }
-    }
-  }
-
   # logging {
   #    target_bucket = "chf-logs"
   #    target_prefix = "s3_server_access_${terraform.workspace}_originals/"
   # }
 }
+
+
+resource "aws_s3_bucket_replication_configuration" "originals" {
+  count  = terraform.workspace == "production" ? 1 : 0
+  bucket = aws_s3_bucket.originals.id
+  # we're not controlling the IAM role with terraform, so we just hardcode it for now.
+  role = "arn:aws:iam::335460257737:role/S3-Backup-Replication"
+  rule {
+    id       = "Backup"
+    priority = 0
+    status   = "Enabled"
+    destination {
+      bucket = aws_s3_bucket.originals_backup[0].arn
+    }
+  }
+}
+
 
 resource "aws_s3_bucket_public_access_block" "originals" {
   bucket = aws_s3_bucket.originals.id


### PR DESCRIPTION
This just fixes a warning at this stage: `replication_configuration` is deprecated in favor of `aws_s3_bucket_replication_configuration`. This will become a breaking change in 4.x, so we're dealing with it now along with all the other changes in Ref #38.

Note that these blocks have no effect in staging.

Note: to prevent replication from happening in staging,
    instead of using `dynamic` blocks as we did before,
   we use `count = terraform.workspace == "production" ? 1 : 0` , which is simpler and consistent with the way we're turning on and off similar `resource` s.