### PR TITLE
Enforce modern TLS for public buckets

### DIFF
--- a/templates/s3_public_read_policy.tftpl
+++ b/templates/s3_public_read_policy.tftpl
@@ -8,6 +8,23 @@ ${jsonencode(
                 Resource  = "arn:aws:s3:::${bucket_name}/*"
                 Sid       = "AddPerm"
             },
+            {
+               Action    = "s3:*"
+               Condition = {
+                   NumericLessThan = {
+                        "s3:TlsVersion" = "1.2"
+                    }
+                }
+                Effect    = "Deny"
+                Principal = {
+                    AWS = "*"
+                }
+                Resource  = [
+                    "arn:aws:s3:::${bucket_name}/*",
+                    "arn:aws:s3:::${bucket_name}",
+                ]
+               Sid       = "EnforceTLSv12orHigher"
+            },
         ]
         Version   = "2012-10-17"
     }


### PR DESCRIPTION
See https://repost.aws/knowledge-center/s3-enforce-modern-tls .
Ref https://github.com/sciencehistory/terraform_scihist_digicoll/issues/49

This will prevent clients on old TLS versions from accessing our public buckets, namely:
**Staging**
- `bucket_derivatives.tf`
- `bucket_derivatives_video.tf`
- `bucket_dzi.tf`
- `bucket_public.tf`
   - (note: this is [already updated in staging](https://s3.console.aws.amazon.com/s3/buckets/scihist-digicoll-staging-public?region=us-east-1&tab=permissions))
 
**Prod:**
all of the above plus

- `bucket_derivatives_backup.tf`
- `bucket_dzi_backup.tf`
