### PR TITLE
Splitting up iam.tf file

### DIFF
--- a/dev_users.tf
+++ b/dev_users.tf
@@ -38,35 +38,6 @@ resource "aws_iam_user" "jrochkind_dev" {
   tags_all = {}
 }
 
-# Access to start mediaconvert jobs:
-# aws_iam_policy.mediaconvert_dev:
-resource "aws_iam_policy" "mediaconvert_dev" {
-  description = "Ability to start mediaconvert jobs, with dev mediaconvert role"
-  name        = "mediaconvert_dev"
-  path        = "/"
-  policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action   = "mediaconvert:*"
-          Effect   = "Allow"
-          Resource = "*"
-          Sid      = "mediaconvertActions"
-        },
-        {
-          Action   = "iam:PassRole"
-          Effect   = "Allow"
-          Resource = "arn:aws:iam::335460257737:role/scihist-digicoll-DEV-MediaConvertRole"
-          Sid      = "iamPassRole"
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
-  tags     = {}
-  tags_all = {}
-}
-
 # aws_iam_group_policy_attachment.dev_users_mediaconvert_dev:
 resource "aws_iam_group_policy_attachment" "dev_users_mediaconvert_dev" {
   group      = aws_iam_group.dev_users.name

--- a/mediaconvert.tf
+++ b/mediaconvert.tf
@@ -1,0 +1,33 @@
+# These roles and policies allow the Mediaconvert service
+# (which we use to make derivatives for video files)
+# to call s3 services on your behalf,
+# in dev, staging and production respectively.
+
+
+# aws_iam_policy.mediaconvert_dev:
+resource "aws_iam_policy" "mediaconvert_dev" {
+  description = "Ability to start mediaconvert jobs, with dev mediaconvert role"
+  name        = "mediaconvert_dev"
+  path        = "/"
+  policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action   = "mediaconvert:*"
+          Effect   = "Allow"
+          Resource = "*"
+          Sid      = "mediaconvertActions"
+        },
+        {
+          Action   = "iam:PassRole"
+          Effect   = "Allow"
+          Resource = "arn:aws:iam::335460257737:role/scihist-digicoll-DEV-MediaConvertRole"
+          Sid      = "iamPassRole"
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  tags     = {}
+  tags_all = {}
+}


### PR DESCRIPTION
Ref #6 
It became clear we will need a whole bunch of files to cover all these resources. For now I'm grouping them by function.
So now we have:
- dev_users.tf
- mediaconvert.tf

The first is everything you need to know about the dev users and their user group.
But split the dev mediaconvert role and policy into a separate file. They will be joined soon by staging and production counterparts.