### PR TITLE
Adding three roles to mediaconvert.tf

### DIFF
--- a/mediaconvert.tf
+++ b/mediaconvert.tf
@@ -4,6 +4,7 @@
 # in dev, staging and production respectively.
 
 
+
 # aws_iam_policy.mediaconvert_dev:
 resource "aws_iam_policy" "mediaconvert_dev" {
   description = "Ability to start mediaconvert jobs, with dev mediaconvert role"
@@ -21,7 +22,7 @@ resource "aws_iam_policy" "mediaconvert_dev" {
         {
           Action   = "iam:PassRole"
           Effect   = "Allow"
-          Resource = "arn:aws:iam::335460257737:role/scihist-digicoll-DEV-MediaConvertRole"
+          Resource = aws_iam_role.dev_mediaconvert_role.arn
           Sid      = "iamPassRole"
         },
       ]
@@ -30,4 +31,117 @@ resource "aws_iam_policy" "mediaconvert_dev" {
   )
   tags     = {}
   tags_all = {}
+}
+
+# aws_iam_role.dev_mediaconvert_role:
+resource "aws_iam_role" "dev_mediaconvert_role" {
+  assume_role_policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = "sts:AssumeRole"
+          Effect = "Allow"
+          Principal = {
+            Service = "mediaconvert.amazonaws.com"
+          }
+          Sid = ""
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  description           = "Allows MediaConvert service to call S3 APIs and API Gateway on your behalf."
+  force_detach_policies = false
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess",
+  ]
+  max_session_duration = 3600
+  name                 = "scihist-digicoll-DEV-MediaConvertRole"
+  path                 = "/"
+  tags                 = {}
+  tags_all             = {}
+
+  inline_policy {
+    name = "S3-scih-data-dev"
+    policy = jsonencode(
+      {
+        Statement = [
+          {
+            Action = [
+              "s3:*",
+              "s3-object-lambda:*",
+            ]
+            Effect = "Allow"
+            Resource = [
+              "arn:aws:s3:::scih-data-dev",
+              "arn:aws:s3:::scih-data-dev/*",
+            ]
+          },
+        ]
+        Version = "2012-10-17"
+      }
+    )
+  }
+}
+
+# aws_iam_role.staging_mediaconvert_role:
+resource "aws_iam_role" "staging_mediaconvert_role" {
+  count = terraform.workspace == "staging" ? 1 : 0
+  assume_role_policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = "sts:AssumeRole"
+          Effect = "Allow"
+          Principal = {
+            Service = "mediaconvert.amazonaws.com"
+          }
+          Sid = ""
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  description           = "Allows MediaConvert service to call S3 APIs and API Gateway on your behalf. STAGING"
+  force_detach_policies = false
+  managed_policy_arns = [
+    aws_iam_policy.bucket_access_from_app_staging[0].arn,
+    "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess",
+  ]
+  max_session_duration = 3600
+  name                 = "scihist-digicoll-staging-MediaConvertRole"
+  path                 = "/"
+  tags                 = {}
+  tags_all             = {}
+}
+
+# aws_iam_role.production_mediaconvert_role:
+resource "aws_iam_role" "production_mediaconvert_role" {
+  count = terraform.workspace == "production" ? 1 : 0
+  assume_role_policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = "sts:AssumeRole"
+          Effect = "Allow"
+          Principal = {
+            Service = "mediaconvert.amazonaws.com"
+          }
+          Sid = ""
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  description           = "Allows MediaConvert service to call S3 APIs and API Gateway on your behalf. PRODUCTION"
+  force_detach_policies = false
+  managed_policy_arns = [
+    aws_iam_policy.bucket_access_from_app_production[0].arn,
+    "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess",
+  ]
+  max_session_duration = 3600
+  name                 = "scihist-digicoll-production-MediaConvertRole"
+  path                 = "/"
+  tags                 = {}
+  tags_all             = {}
 }


### PR DESCRIPTION
Ref #6.

Adds three roles to Terraform that were not described before.

- `aws_iam_role.dev_mediaconvert_role`
- `aws_iam_role.staging_mediaconvert_role`
- `aws_iam_role.production_mediaconvert_role`


For now we are putting them in `mediaconvert.tf` but in a future PR we will move them into a file that will contain only `iam_role` items.