### PR TITLE
Add descriptions for the backup, production and staging users

### DIFF
--- a/iam_user_backup.tf
+++ b/iam_user_backup.tf
@@ -1,0 +1,15 @@
+# aws_iam_user.backup:
+resource "aws_iam_user" "backup" {
+  name = "s3_backup"
+  path = "/"
+  tags = {
+    "Associated rake task" = "bundle exec rake scihist:copy_database_to_s3"
+    "Description"          = "Used by a Heroku scheduled job to put nightly backups of the Digital Collections database onto our S3 backup bucket."
+    "See also"             = "https://dashboard.heroku.com/apps/scihist-digicoll-production/scheduler"
+  }
+  tags_all = {
+    "Associated rake task" = "bundle exec rake scihist:copy_database_to_s3"
+    "Description"          = "Used by a Heroku scheduled job to put nightly backups of the Digital Collections database onto our S3 backup bucket."
+    "See also"             = "https://dashboard.heroku.com/apps/scihist-digicoll-production/scheduler"
+  }
+}

--- a/iam_user_production.tf
+++ b/iam_user_production.tf
@@ -1,0 +1,11 @@
+# aws_iam_user.production:
+resource "aws_iam_user" "production" {
+  name = "s3_digicoll_production"
+  path = "/"
+  tags = {
+    "Description" = "Used by the production app on Heroku to access all the s3 buckets it needs."
+  }
+  tags_all = {
+    "Description" = "Used by the production app on Heroku to access all the s3 buckets it needs."
+  }
+}

--- a/iam_user_staging.tf
+++ b/iam_user_staging.tf
@@ -1,0 +1,11 @@
+# aws_iam_user.staging:
+resource "aws_iam_user" "staging" {
+  name = "s3_digicoll_staging"
+  path = "/"
+  tags = {
+    "Description" = "Used by the staging app on Heroku to access all the s3 buckets it needs."
+  }
+  tags_all = {
+    "Description" = "Used by the staging app on Heroku to access all the s3 buckets it needs."
+  }
+}


### PR DESCRIPTION
This adds Terraform descriptions of:
 - the IAM user used from nightly backups from Heroku to the S3 backup bucket;
 - the IAM user used by the prod app to connect to all s3 buckets it needs;
 - the IAM user used by the staging app to connect to all s3 buckets it needs;
This is pretty straightforward and I plan to self-merge this (don't really like having this unmerged over the weekend).