### PR TITLE
Fix CloudFront caching of Rails static assets

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -18,15 +18,13 @@ resource "aws_cloudfront_distribution" "rails_static_assets" {
       "OPTIONS",
     ]
 
+    compress = true
+
     target_origin_id       = "scihist-digicoll-${terraform.workspace}.herokuapp.com"
     viewer_protocol_policy = "https-only"
 
-    forwarded_values {
-      query_string = false
-      cookies {
-        forward = "none"
-      }
-    }
+    # AWS Managed-CachingOptimized policy
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
   }
 
   origin {


### PR DESCRIPTION
Our Rails static assetes are all immutable (filename changes if content changes) and served with far-future cache headers. They can be cached forever by both cloudfront (CDN) and the browser.

While they were being served with far-future cache headers to the browser -- it turns out CloudFront wasn't actually caching them!  Possibly slightly effecting delivery performance, and causing CloudFront to send extra un-needed requests to our server. Probably isn't responsible for that much load on our server, but the whole point of using CloudFront is to avoid these requests to our server.

I could tell CloudFront wasn't caching because of looking at HTTP response headers on cloudfront responses for these assets, eg https://d2ih2oyx008jki.cloudfront.net/vite/assets/application-Fojt9GGu.css .  I was seeing "X-Cache: RefreshHit from cloudfront" -- the "refresh" means CloudFront was sending our server a conditional GET request to test freshness instead of using a cached copy. We want to see "X-Cache: Hit" once it's cached.

The Cloudfront "behavior" was using `Legacy cache settings` that apparently weren't set right; we switched to `Cache policy and origin request policy (recommended)` with managed `CachingOptimized` policy. From studying docs and looking in practice this seems to do the right thing for our immutable content that is alread delivered from origin with far-future cache headers.

This has already been done in staging, but

- [ ] terraform apply in production

