### PR TITLE
restore CORS config necessary for S3 buckets to work directly

### DIFF
--- a/bucket_derivatives_video.tf
+++ b/bucket_derivatives_video.tf
@@ -81,6 +81,26 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "derivatives_video
   }
 }
 
+# probably not really necessary now that we're fronting with
+# cloudfront and having CF add CORS headers
+resource "aws_s3_bucket_cors_configuration" "derivatives-video" {
+  bucket = aws_s3_bucket.derivatives_video.id
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+}
+
 # Video-derviatives cloudfront, in front of S3
 # * cheaper price class North America/Europe only
 # * add on cache-control header with far future caches for clients,

--- a/bucket_dzi.tf
+++ b/bucket_dzi.tf
@@ -113,6 +113,26 @@ resource "aws_cloudfront_distribution" "dzi" {
   }
 }
 
+# probably not really necessary now that we're fronting with
+# cloudfront and having CF add CORS headers
+resource "aws_s3_bucket_cors_configuration" "dzi" {
+  bucket = aws_s3_bucket.dzi.id
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 43200
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "dzi" {
   bucket = aws_s3_bucket.dzi.id
 


### PR DESCRIPTION
For our transition before we are on cloudfront, plus probably good to leave in place in case we need to switch back, doens't hurt
