### PR TITLE
S3 and Cloudfront Logging

### DIFF
--- a/bucket_derivatives.tf
+++ b/bucket_derivatives.tf
@@ -109,6 +109,12 @@ resource "aws_cloudfront_distribution" "derivatives" {
     "S3-Bucket-Name" = "${local.name_prefix}-derivatives"
     "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-derivatives.s3"
   }
+
+  logging_config {
+    bucket            = aws_s3_bucket.chf-logs.bucket_domain_name
+    include_cookies   = false
+    prefix            = "cloudfront_access_logs/${terraform.workspace}-derivatives/"
+  }
 }
 
 
@@ -172,3 +178,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "derivatives" {
     }
   }
 }
+
+# $ terraform import aws_s3_bucket_logging.originals_logging scihist-digicoll-staging-originals
+resource "aws_s3_bucket_logging" "derivatives_logging" {
+  bucket        = aws_s3_bucket.derivatives.id
+  target_bucket = aws_s3_bucket.chf-logs.id
+  target_prefix = "s3_access_logs/${terraform.workspace}-derivatives/"
+}
+

--- a/bucket_derivatives_video.tf
+++ b/bucket_derivatives_video.tf
@@ -101,6 +101,13 @@ resource "aws_s3_bucket_cors_configuration" "derivatives-video" {
   }
 }
 
+# $ terraform import aws_s3_bucket_logging.originals_logging scihist-digicoll-staging-originals
+resource "aws_s3_bucket_logging" "derivatives_video_logging" {
+  bucket        = aws_s3_bucket.derivatives_video.id
+  target_bucket = aws_s3_bucket.chf-logs.id
+  target_prefix = "s3_access_logs/${terraform.workspace}-derivatives-video/"
+}
+
 # Video-derviatives cloudfront, in front of S3
 # * cheaper price class North America/Europe only
 # * add on cache-control header with far future caches for clients,
@@ -168,5 +175,11 @@ resource "aws_cloudfront_distribution" "derivatives-video" {
 
   viewer_certificate {
     cloudfront_default_certificate = true
+  }
+
+  logging_config {
+    bucket            = aws_s3_bucket.chf-logs.bucket_domain_name
+    include_cookies   = false
+    prefix            = "cloudfront_access_logs/${terraform.workspace}-derivatives-video/"
   }
 }

--- a/bucket_dzi.tf
+++ b/bucket_dzi.tf
@@ -111,6 +111,19 @@ resource "aws_cloudfront_distribution" "dzi" {
     "S3-Bucket-Name" = "${local.name_prefix}-dzi"
     "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-dzi.s3"
   }
+
+  logging_config {
+    bucket            = aws_s3_bucket.chf-logs.bucket_domain_name
+    include_cookies   = false
+    prefix            = "cloudfront_access_logs/${terraform.workspace}-dzi/"
+  }
+}
+
+# $ terraform import aws_s3_bucket_logging.originals_logging scihist-digicoll-staging-originals
+resource "aws_s3_bucket_logging" "dzi" {
+  bucket        = aws_s3_bucket.dzi.id
+  target_bucket = aws_s3_bucket.chf-logs.id
+  target_prefix = "s3_access_logs/${terraform.workspace}-dzi/"
 }
 
 # probably not really necessary now that we're fronting with

--- a/bucket_logs.tf
+++ b/bucket_logs.tf
@@ -13,3 +13,42 @@ resource "aws_s3_bucket" "chf-logs" {
     "Type"           = "S3"
   }
 }
+
+# in s3_access_logs/ and cloudfront_access_logs/ prefixes, delete objects after 13 months
+resource "aws_s3_bucket_lifecycle_configuration" "chf_logs" {
+  bucket       = "chf-logs"
+
+  rule {
+    id     = "expire_s3_access_logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "s3_access_logs/"
+    }
+
+    expiration {
+      days = 395
+      expired_object_delete_marker = false
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 395
+    }
+  }
+
+  rule {
+    id     = "expire_cloudfront_access_logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "cloudfront_access_logs/"
+    }
+
+    expiration {
+      days = 395
+      expired_object_delete_marker = false
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 395
+    }
+  }
+}

--- a/bucket_logs.tf
+++ b/bucket_logs.tf
@@ -1,0 +1,15 @@
+# This bucket is shared by both production and staging at present....
+
+# this terraform config is not right in that both staging and prod terraform workspaces currently think
+# they control this same bucket. Should prob fix, but it's worked up to now and am not fixing right now.
+
+resource "aws_s3_bucket" "chf-logs" {
+  force_destroy = false
+  bucket        = "chf-logs"
+  tags = {
+    "Role"           = "Production"
+    "S3-Bucket-Name" = "chf-logs"
+    "Service"        = "Systems"
+    "Type"           = "S3"
+  }
+}

--- a/bucket_ondemand_derivatives.tf
+++ b/bucket_ondemand_derivatives.tf
@@ -61,6 +61,7 @@ resource "aws_s3_bucket_policy" "ondemand_derivatives" {
 #   restrict_public_buckets = true
 # }
 
+
 resource "aws_cloudfront_distribution" "ondemand_derivatives" {
   comment         = "${terraform.workspace}-ondemand-derivatives S3"
   enabled         = true
@@ -120,6 +121,12 @@ resource "aws_cloudfront_distribution" "ondemand_derivatives" {
     "S3-Bucket-Name" = "${local.name_prefix}-ondemand-derivatives"
     "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-ondemand-derivatives.s3"
   }
+
+  logging_config {
+    bucket            = aws_s3_bucket.chf-logs.bucket_domain_name
+    include_cookies   = false
+    prefix            = "cloudfront_access_logs/${terraform.workspace}-ondemand-derivatives/"
+  }
 }
 
 
@@ -140,4 +147,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "ondemand_derivati
       sse_algorithm = "AES256"
     }
   }
+}
+
+# $ terraform import aws_s3_bucket_logging.originals_logging scihist-digicoll-staging-originals
+resource "aws_s3_bucket_logging" "ondemand_derivatives" {
+  bucket        = aws_s3_bucket.ondemand_derivatives.id
+  target_bucket = aws_s3_bucket.chf-logs.id
+  target_prefix = "s3_access_logs/${terraform.workspace}-ondemand-derivatives/"
 }

--- a/bucket_originals.tf
+++ b/bucket_originals.tf
@@ -157,18 +157,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "originals" {
   }
 }
 
-# We may want to put this aws_s3_bucket in a separate file; would be more consistent with the existing setup.
-resource "aws_s3_bucket" "chf-logs" {
-  force_destroy = false
-  bucket        = "chf-logs"
-  tags = {
-    "Role"           = "Production"
-    "S3-Bucket-Name" = "chf-logs"
-    "Service"        = "Systems"
-    "Type"           = "S3"
-  }
-}
-
 # % terraform import aws_s3_bucket_logging.example bucket-name
 # resource "aws_s3_bucket_logging" "originals_logging" {
 #   bucket        = aws_s3_bucket.originals.id

--- a/bucket_originals.tf
+++ b/bucket_originals.tf
@@ -96,6 +96,12 @@ resource "aws_cloudfront_distribution" "originals" {
     "S3-Bucket-Name" = "${local.name_prefix}-originals"
     "Cloudfront-Distribution-Origin-Id" = "${terraform.workspace}-originals.s3"
   }
+
+  logging_config {
+    bucket            = aws_s3_bucket.chf-logs.bucket_domain_name
+    include_cookies   = false
+    prefix            = "cloudfront_access_logs/${terraform.workspace}-originals"
+  }
 }
 
 resource "aws_s3_bucket_policy" "originals" {
@@ -157,9 +163,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "originals" {
   }
 }
 
-# % terraform import aws_s3_bucket_logging.example bucket-name
-# resource "aws_s3_bucket_logging" "originals_logging" {
-#   bucket        = aws_s3_bucket.originals.id
-#   target_bucket = aws_s3_bucket.chf-logs.id
-#   target_prefix = "s3_server_access_${terraform.workspace}_originals/"
-# }
+# $ terraform import aws_s3_bucket_logging.originals_logging scihist-digicoll-staging-originals
+resource "aws_s3_bucket_logging" "originals_logging" {
+  bucket        = aws_s3_bucket.originals.id
+  target_bucket = aws_s3_bucket.chf-logs.id
+  target_prefix = "s3_access_logs/${terraform.workspace}-originals/"
+}
+
+


### PR DESCRIPTION
Set up AWS logging for our major 5 public-facing S3 bucket and the cloudfront distros in front of them. 

To `chf-logs/cloudfront_access_logs/${bucket-name}` and `chf-logs/s3_access_logs/${bucket-name}`

With lifecycle rules on `chf-logs` bucket to remove files at those prefixes after 13 months

- move chf-logs bucket to own terraform config
- delete old S3 and cloudfront access logs after 13 months
- set up logging to chf-logs for major public-facing buckets and cloudfront distros in front
